### PR TITLE
Remove auth for /movies endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,6 @@ app.get("/", passport.authenticate("jwt", { session: false }), (req, res) => {
 // READ all movie data
 app.get(
   "/movies",
-  passport.authenticate("jwt", { session: false }),
   async (req, res) => {
     await Movies.find()
       .then((movies) => {


### PR DESCRIPTION
Delete passport authentication middleware from /movies endpoint, in order to render data in the React client.